### PR TITLE
fix: plugin loading collision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "player-one"
+name = "player_one"
 version = "0.1.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A Neovim plugin that adds retro gaming charm to your coding experience with 8-bi
 
 ## Quickstart
 
-1. Install with your favorite package manager:
+1. Install with a plugin manager of your choice.
 
 2. Restart NeoVim and you should now hear:
 

--- a/lua/player-one/binary/download.lua
+++ b/lua/player-one/binary/download.lua
@@ -8,8 +8,8 @@ function M.get_plugin_root()
 end
 
 function M.get_binary_dir()
-	local data_dir = vim.fn.stdpath("data")
-	return data_dir .. "/player-one/bin"
+	local plugin_root = M.get_plugin_root()
+	return plugin_root .. "/bin"
 end
 
 function M.get_binary_path()

--- a/lua/player-one/binary/download.lua
+++ b/lua/player-one/binary/download.lua
@@ -139,7 +139,9 @@ end
 
 function M.ensure_binary()
 	local current_version = M.get_current_version()
-	local required_version = "v0.1.0" -- or fetch latest from GitHub API
+	local required_version = vim.fn
+		.system("curl -s https://api.github.com/repos/player-one/binary/releases/latest | grep 'tag_name' | cut -d '\"' -f 4")
+		:gsub("%s+", "")
 
 	if current_version ~= required_version then
 		vim.notify("PlayerOne: Downloading binary...", vim.log.levels.INFO)

--- a/lua/player-one/binary/download.lua
+++ b/lua/player-one/binary/download.lua
@@ -140,7 +140,9 @@ end
 function M.ensure_binary()
 	local current_version = M.get_current_version()
 	local required_version = vim.fn
-		.system("curl -s https://api.github.com/repos/player-one/binary/releases/latest | grep 'tag_name' | cut -d '\"' -f 4")
+		.system(
+			"curl -s https://api.github.com/repos/jackplus-xyz/player-one.nvim/releases/latest | grep 'tag_name' | cut -d '\"' -f 4"
+		)
 		:gsub("%s+", "")
 
 	if current_version ~= required_version then

--- a/lua/player-one/binary/init.lua
+++ b/lua/player-one/binary/init.lua
@@ -15,7 +15,16 @@ function M.load_binary()
 	-- Try loading from development build first
 	package.cpath = package.cpath .. ";" .. dev_path
 
-	local ok, lib = pcall(require, "libplayerone")
+	local old_cpath = package.cpath
+	package.cpath = dev_path
+
+	local ok, lib = pcall(require, "libplayer_one")
+	if ok then
+		return lib
+	end
+
+	package.cpath = old_cpath
+
 	if ok then
 		return lib
 	end

--- a/lua/player-one/binary/init.lua
+++ b/lua/player-one/binary/init.lua
@@ -1,3 +1,6 @@
+-- Binary compilation and loading functionality adapted from:
+-- https://github.com/Saghen/blink.cmp/tree/main/lua/blink/cmp/fuzzy
+
 local system = require("player-one.binary.system")
 local download = require("player-one.binary.download")
 

--- a/lua/player-one/binary/init.lua
+++ b/lua/player-one/binary/init.lua
@@ -13,17 +13,11 @@ function M.load_binary()
 	local dev_path = plugin_root .. "../../../target/release/" .. prefix .. "player_one" .. ext
 
 	-- Try loading from development build first
-	package.cpath = package.cpath .. ";" .. dev_path
-
-	local old_cpath = package.cpath
-	package.cpath = dev_path
+	local original_cpath = package.cpath
+	package.cpath = dev_path .. ";" .. original_cpath
 
 	local ok, lib = pcall(require, "libplayer_one")
-	if ok then
-		return lib
-	end
-
-	package.cpath = old_cpath
+	package.cpath = original_cpath -- restore immediately after loading
 
 	if ok then
 		return lib

--- a/lua/player-one/binary/init.lua
+++ b/lua/player-one/binary/init.lua
@@ -6,43 +6,47 @@ local download = require("player-one.binary.download")
 
 local M = {}
 
+-- Helper: try to load a library from an absolute path
+local function load_lib(path, symbol)
+	local loader, err = package.loadlib(path, symbol)
+	if not loader then
+		return nil, err
+	end
+	return loader(), nil
+end
+
 function M.load_binary()
 	local ext = system.get_lib_extension()
 	local prefix = system.get_lib_prefix()
+
+	-- Build the fully qualified path to the development binary
 	local plugin_root = debug.getinfo(1).source:match("@?(.*/)")
-	local dev_path = plugin_root .. "../../../target/release/" .. prefix .. "player_one" .. ext
+	local dev_binary = plugin_root .. "../../../target/release/" .. prefix .. "player_one" .. ext
 
-	-- Try loading from development build first
-	local original_cpath = package.cpath
-	package.cpath = dev_path .. ";" .. original_cpath
-
-	local ok, lib = pcall(require, "libplayer_one")
-	package.cpath = original_cpath -- restore immediately after loading
-
-	if ok then
-		return lib
+	-- Try loading development binary if it exists.
+	if vim.fn.filereadable(dev_binary) == 1 then
+		local lib, err = load_lib(dev_binary, "luaopen_libplayer_one")
+		if lib then
+			return lib
+		else
+			vim.notify("Failed to load dev binary: " .. err, vim.log.levels.WARN)
+		end
 	end
 
-	-- Try loading from installed location
+	-- Fallback: try installed binary from download location.
 	local bin_dir = download.get_binary_dir()
-	local install_path = bin_dir .. "/" .. prefix .. "player_one" .. ext
-	package.cpath = package.cpath .. ";" .. install_path
+	local install_binary = bin_dir .. "/" .. prefix .. "player_one" .. ext
 
-	ok, lib = pcall(require, "libplayerone")
-	if ok then
-		return lib
+	if vim.fn.filereadable(install_binary) == 1 then
+		local lib, err = load_lib(install_binary, "luaopen_libplayerone")
+		if lib then
+			return lib
+		else
+			vim.notify("Failed to load installed binary: " .. err, vim.log.levels.WARN)
+		end
 	end
 
-	-- Download and try again
-	download.ensure_binary()
-
-	ok, lib = pcall(require, "libplayerone")
-	if ok then
-		return lib
-	end
-
-	error("Failed to load playerone binary")
+	error("Failed to load player-one binary")
 end
 
--- Return the loaded binary or throw an error
 return M.load_binary()


### PR DESCRIPTION
This pull request includes several significant changes to the `player-one` project, focusing on renaming the package, updating the installation instructions, improving binary download functionality, and enhancing the binary loading process.

### Package Renaming:
* Renamed the package from `player-one` to `player_one` in `Cargo.toml` to follow naming conventions.

### Documentation Update:
* Updated the installation instructions in `README.md` to suggest using a plugin manager of choice instead of a specific package manager.

### Binary Download Improvements:
* Modified the `M.get_binary_dir` function to use `M.get_plugin_root` for determining the binary directory path.
* Updated the `M.ensure_binary` function to fetch the latest version from the GitHub API instead of using a hardcoded version.

### Binary Loading Enhancements:
* Added a helper function `load_lib` in `lua/player-one/binary/init.lua` to try loading a library from an absolute path and handle errors.
* Refactored the `M.load_binary` function to use the new `load_lib` helper and added checks for the readability of development and installed binaries, with appropriate error notifications.