### PR TITLE
Feat/sound toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,17 +91,17 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
   ---This multiplies with each sound's individual volume
   master_volume = 0.5,
 
-  ---@type table<string, boolean> Individual sound event toggles (default: all true)
-  ---Enable or disable specific sound events
-  sound_toggles = {
-    VimEnter = true,        -- Startup melody
-    VimLeavePre = true,     -- Exit sound
-    TextChangedI = true,    -- Typing sounds in insert mode
-    BufWritePost = true,    -- File save confirmation
-    TextYankPost = true,    -- Copy/yank confirmation
-    CursorMoved = true,     -- Cursor movement sounds
-    CmdlineEnter = true,    -- Command mode entry
-    CmdlineChanged = true,  -- Command line typing
+  ---@type table<string, table<string, boolean>> Theme-specific sound disables
+  ---Only specify sounds you want to disable (all sounds enabled by default)
+  theme_config = {
+    -- Example: disable specific sounds for specific themes
+    -- chiptune = {
+    --   CursorMoved = false,    -- Disable cursor movement sounds for chiptune
+    --   TextChangedI = false,   -- Disable typing sounds for chiptune
+    -- },
+    -- synth = {
+    --   VimEnter = false,       -- Disable startup melody for synth theme
+    -- },
   },
 
   ---@type boolean Whether to print debug messages (default: false)
@@ -155,25 +155,35 @@ Example:
 
 ### Sound Control
 
-You can enable or disable individual sound events using the `sound_toggles` configuration:
+You can disable individual sound events for specific themes using the `theme_config` option. **All sounds are enabled by default** - you only need to specify what you want to disable:
 
 ```lua
 {
   "jackplus-xyz/player-one.nvim",
   opts = {
-    sound_toggles = {
-      VimEnter = true,        -- Keep startup melody
-      VimLeavePre = true,     -- Keep exit sound
-      TextChangedI = false,   -- Disable typing sounds (common preference)
-      BufWritePost = true,    -- Keep save confirmation
-      TextYankPost = true,    -- Keep copy confirmation
-      CursorMoved = false,    -- Disable cursor sounds (most common)
-      CmdlineEnter = true,    -- Keep command mode entry
-      CmdlineChanged = false, -- Disable command line typing
+    theme = "chiptune",
+    theme_config = {
+      chiptune = {
+        CursorMoved = false,    -- Disable cursor sounds (most common!)
+        TextChangedI = false,   -- Disable typing sounds
+      },
+      synth = {
+        VimEnter = false,       -- Disable startup melody for synth theme
+        CmdlineChanged = false, -- Disable command line typing
+      },
+      crystal = {
+        -- Maybe you love all crystal sounds, so leave this empty!
+      }
     }
   }
 }
 ```
+
+This elegant approach means:
+
+- **Clean config** - Only specify what you want to turn off
+- **Theme-specific** - Different sound preferences for different themes
+- **Sensible defaults** - All sounds work out of the box
 
 For advanced configuration, see [Wiki](https://github.com/jackplus-xyz/player-one.nvim/wiki).
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ https://github.com/user-attachments/assets/f72a038f-507c-49cc-9506-37494cbf8ed8
 1. Install with a plugin manager of your choice.
 
 2. Restart NeoVim and you should now hear:
-
    - A startup melody when Neovim launches
    - Typing sounds in insert mode
    - Save confirmation sounds
@@ -87,10 +86,23 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
   ---@type string|PlayerOne.Theme Theme name or custom sounds table (default: "chiptune")
   ---Available presets: "chiptune", "crystal", "synth"
   theme = "chiptune",
-  
+
   ---@type number Master volume for all sounds (0.0-1.0, default: 0.5)
   ---This multiplies with each sound's individual volume
   master_volume = 0.5,
+
+  ---@type table<string, boolean> Individual sound event toggles (default: all true)
+  ---Enable or disable specific sound events
+  sound_toggles = {
+    VimEnter = true,        -- Startup melody
+    VimLeavePre = true,     -- Exit sound
+    TextChangedI = true,    -- Typing sounds in insert mode
+    BufWritePost = true,    -- File save confirmation
+    TextYankPost = true,    -- Copy/yank confirmation
+    CursorMoved = true,     -- Cursor movement sounds
+    CmdlineEnter = true,    -- Command mode entry
+    CmdlineChanged = true,  -- Command line typing
+  },
 
   ---@type boolean Whether to print debug messages (default: false)
   debug = false,
@@ -141,6 +153,28 @@ Example:
 }
 ```
 
+### Sound Control
+
+You can enable or disable individual sound events using the `sound_toggles` configuration:
+
+```lua
+{
+  "jackplus-xyz/player-one.nvim",
+  opts = {
+    sound_toggles = {
+      VimEnter = true,        -- Keep startup melody
+      VimLeavePre = true,     -- Keep exit sound
+      TextChangedI = false,   -- Disable typing sounds (common preference)
+      BufWritePost = true,    -- Keep save confirmation
+      TextYankPost = true,    -- Keep copy confirmation
+      CursorMoved = false,    -- Disable cursor sounds (most common)
+      CmdlineEnter = true,    -- Keep command mode entry
+      CmdlineChanged = false, -- Disable command line typing
+    }
+  }
+}
+```
+
 For advanced configuration, see [Wiki](https://github.com/jackplus-xyz/player-one.nvim/wiki).
 
 ### Volume Control
@@ -153,10 +187,12 @@ The plugin has a two-level volume system:
 The final volume is calculated as: `sound_vol × master_volume`
 
 For example:
+
 - If `master_volume = 0.5` and a sound has `volume = 0.8`, it will play at `0.4` volume
 - If `master_volume = 0.5` and no volume is specified for a sound, it defaults to a base of `1.0`, resulting in `0.5` volume
 
 This allows you to:
+
 - Control all sound volumes at once with the master volume
 - Fine-tune individual sounds relative to each other
 

--- a/lua/player-one/config.lua
+++ b/lua/player-one/config.lua
@@ -12,55 +12,56 @@ local M = {}
 
 ---@type PlayerOne.Config
 local defaults = {
-    is_enabled = true,
-    min_interval = 0.05,
-    theme = "chiptune",
-    master_volume = 0.5,
-    sound_toggles = {
-        VimEnter = true,
-        VimLeavePre = true,
-        TextChangedI = true,
-        BufWritePost = true,
-        TextYankPost = true,
-        CursorMoved = true,
-        CmdlineEnter = true,
-        CmdlineChanged = true,
-    },
-    binary = {
-        auto_update = true,
-        cache_timeout = 3600,
-        download_timeout = 60,
-        verify_checksum = true,
-        use_development = true,
-        github_api_token = nil,
-        proxy = {
-            url = nil,
-            from_env = true,
-        },
-    },
-    debug = false,
+	is_enabled = true,
+	min_interval = 0.05,
+	theme = "chiptune",
+	master_volume = 0.5,
+	theme_config = {
+		-- Only specify sounds you want to disable
+		-- All sounds are enabled by default
+	},
+	binary = {
+		auto_update = true,
+		cache_timeout = 3600,
+		download_timeout = 60,
+		verify_checksum = true,
+		use_development = true,
+		github_api_token = nil,
+		proxy = {
+			url = nil,
+			from_env = true,
+		},
+	},
+	debug = false,
 }
 
 -- Available built-in themes
 ---@type string[] List of available theme names
 M.themes = { "chiptune", "synth", "crystal" }
 
---- Check if a sound event is enabled based on toggle configuration
+--- Check if a sound event is enabled for the current theme
 ---@param event string The event name to check
 ---@return boolean enabled Whether the event should play sounds
 function M.is_sound_enabled(event)
-    if not M.is_enabled then
-        return false
-    end
-    
-    -- Check if the specific event is enabled (default to true for unknown events)
-    if M.sound_toggles[event] ~= nil then
-        return M.sound_toggles[event]
-    end
-    
-    return true
-end
+	if not M.is_enabled then
+		return false
+	end
 
+	-- Get current theme name
+	local current_theme = M.curr_theme or M.theme
+	if type(current_theme) == "table" then
+		-- Custom theme - default to enabled
+		return true
+	end
+
+	-- Check theme-specific toggle (only if explicitly set to false)
+	if M.theme_config[current_theme] and M.theme_config[current_theme][event] == false then
+		return false
+	end
+
+	-- Default to enabled (all sounds enabled unless explicitly disabled)
+	return true
+end
 
 -- Internal state properties
 ---@type boolean Whether cursor movement sounds are enabled
@@ -97,49 +98,49 @@ M.curr_theme = nil
 --- })
 ---]]
 function M.setup(options)
-    options = options or {}
-    M.options = vim.deepcopy(defaults)
-    M.options = vim.tbl_deep_extend("force", M.options, options)
+	options = options or {}
+	M.options = vim.deepcopy(defaults)
+	M.options = vim.tbl_deep_extend("force", M.options, options)
 
-    -- Copy options to top level for direct access
-    for k, v in pairs(M.options) do
-        M[k] = v
-    end
+	-- Copy options to top level for direct access
+	for k, v in pairs(M.options) do
+		M[k] = v
+	end
 
-    -- Handle master_volume validation
-    if options.master_volume ~= nil then
-        M.master_volume = math.max(0.0, math.min(1.0, options.master_volume))
-    end
+	-- Handle master_volume validation
+	if options.master_volume ~= nil then
+		M.master_volume = math.max(0.0, math.min(1.0, options.master_volume))
+	end
 
-    -- Handle theme setup
-    if options.theme then
-        M.curr_theme = options.theme
-    end
+	-- Handle theme setup
+	if options.theme then
+		M.curr_theme = options.theme
+	end
 
-    -- Add user theme if a custom theme table was provided
-    if type(options.theme) == "table" then
-        table.insert(M.themes, "user")
-    end
+	-- Add user theme if a custom theme table was provided
+	if type(options.theme) == "table" then
+		table.insert(M.themes, "user")
+	end
 
-    -- Create autocmd group for plugin events
-    ---@type number Autocmd group ID
-    M.group = vim.api.nvim_create_augroup("PlayerOne", { clear = true })
+	-- Create autocmd group for plugin events
+	---@type number Autocmd group ID
+	M.group = vim.api.nvim_create_augroup("PlayerOne", { clear = true })
 
-    local Api = require("player-one.api")
-    Api.setup()
-    setmetatable(M, Api)
+	local Api = require("player-one.api")
+	Api.setup()
+	setmetatable(M, Api)
 
-    if M.is_enabled then
-        Api.enable()
-    end
+	if M.is_enabled then
+		Api.enable()
+	end
 end
 
 ---Reload the binary
 ---@return boolean success Whether reload succeeded
 function M.reload_binary()
-    local binary = require("player-one.binary")
-    binary.clear_cache()
-    return binary.load_binary() ~= nil
+	local binary = require("player-one.binary")
+	binary.clear_cache()
+	return binary.load_binary() ~= nil
 end
 
 return M

--- a/lua/player-one/config.lua
+++ b/lua/player-one/config.lua
@@ -16,6 +16,16 @@ local defaults = {
     min_interval = 0.05,
     theme = "chiptune",
     master_volume = 0.5,
+    sound_toggles = {
+        VimEnter = true,
+        VimLeavePre = true,
+        TextChangedI = true,
+        BufWritePost = true,
+        TextYankPost = true,
+        CursorMoved = true,
+        CmdlineEnter = true,
+        CmdlineChanged = true,
+    },
     binary = {
         auto_update = true,
         cache_timeout = 3600,
@@ -34,6 +44,23 @@ local defaults = {
 -- Available built-in themes
 ---@type string[] List of available theme names
 M.themes = { "chiptune", "synth", "crystal" }
+
+--- Check if a sound event is enabled based on toggle configuration
+---@param event string The event name to check
+---@return boolean enabled Whether the event should play sounds
+function M.is_sound_enabled(event)
+    if not M.is_enabled then
+        return false
+    end
+    
+    -- Check if the specific event is enabled (default to true for unknown events)
+    if M.sound_toggles[event] ~= nil then
+        return M.sound_toggles[event]
+    end
+    
+    return true
+end
+
 
 -- Internal state properties
 ---@type boolean Whether cursor movement sounds are enabled

--- a/lua/player-one/utils.lua
+++ b/lua/player-one/utils.lua
@@ -238,7 +238,7 @@ function M._create_autocmds(autocmd, sound, callback)
     vim.api.nvim_create_autocmd(autocmd, {
         group = Config.group,
         callback = function()
-            if Config.is_enabled then
+            if Config.is_enabled and Config.is_sound_enabled(autocmd) then
                 if callback then
                     if type(callback) == "function" then
                         callback(sound)
@@ -298,7 +298,11 @@ function M.load_theme(theme)
         if not v.sound then
             error(string.format("Missing 'sound' in sound configuration at index %d", i))
         end
-        M._create_autocmds(v.event, v.sound, v.callback)
+        
+        -- Only create autocmds for enabled sound events
+        if Config.is_sound_enabled(v.event) then
+            M._create_autocmds(v.event, v.sound, v.callback)
+        end
     end
 end
 


### PR DESCRIPTION
This pull request introduces a new feature to `player-one.nvim` that allows users to customize sound behavior on a per-theme basis. It also includes updates to the documentation and implementation to support this feature. The most important changes include adding the `theme_config` option, implementing a utility function to check sound event enablement, and updating the plugin's behavior to respect these configurations.

### Documentation Updates:
* Added a new section in `README.md` explaining the `theme_config` option, which allows users to disable specific sound events for individual themes. Examples and benefits of this feature are provided. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R94-R106) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R156-R187)

### Feature Implementation:
* Introduced the `theme_config` option in `lua/player-one/config.lua`, enabling users to specify theme-specific sound settings. All sounds are enabled by default unless explicitly disabled.
* Added the `M.is_sound_enabled` function in `lua/player-one/config.lua` to determine if a sound event is enabled for the current theme. This function checks the `theme_config` and defaults to enabling sounds unless explicitly disabled.

### Plugin Behavior Updates:
* Updated the `M._create_autocmds` function in `lua/player-one/utils.lua` to only create autocmds for sound events that are enabled based on the `theme_config` settings.
* Modified the `M.load_theme` function in `lua/player-one/utils.lua` to respect the `theme_config` when loading theme-specific sound events.